### PR TITLE
Set b:did_indent later, so that python.vim defines GetPythonIndent().

### DIFF
--- a/indent/bzl.vim
+++ b/indent/bzl.vim
@@ -18,12 +18,13 @@
 if exists('b:did_indent')
   finish
 endif
-let b:did_indent = 1
 
 " Load base python indent.
 if !exists('*GetPythonIndent')
   source $VIMRUNTIME/indent/python.vim
 endif
+
+let b:did_indent = 1
 
 " Only enable bzl google indent if python google indent is enabled.
 if !get(g:, 'no_google_python_indent')


### PR DESCRIPTION
This replays a fix that was made internally after we staged the initial repository.
