### PR TITLE
Use runtime! to search the whole of &runtimepath.

### DIFF
--- a/indent/bzl.vim
+++ b/indent/bzl.vim
@@ -22,7 +22,7 @@ let b:did_indent = 1
 
 " Load base python indent.
 if !exists('*GetPythonIndent')
-  source $VIMRUNTIME/indent/python.vim
+  runtime! indent/python.vim
 endif
 
 " Only enable bzl google indent if python google indent is enabled.


### PR DESCRIPTION
This is consistent with how other indent scripts source dependencies, rather than only looking in `$VIMRUNTIME`. (In theory, the scripts might not even be in `$VIMRUNTIME` to start with: they might be in `~/.vim/`.)
