### PR TITLE
Detect BUILD.bazel files as bzl

### DIFF
--- a/ftdetect/bzl.vim
+++ b/ftdetect/bzl.vim
@@ -12,4 +12,4 @@
 " See the License for the specific language governing permissions and
 " limitations under the License.
 
-autocmd BufRead,BufNewFile *.bzl,BUILD,WORKSPACE setfiletype bzl
+autocmd BufRead,BufNewFile *.bzl,BUILD,BUILD.bazel,WORKSPACE setfiletype bzl


### PR DESCRIPTION
With [Bazel 0.4.1](https://github.com/bazelbuild/bazel/blob/master/CHANGELOG.md#release-041-2016-11-21), `BUILD` files can also be called `BUILD.bazel`.