### PR TITLE
Add *.BUILD and BUILD.* to bazel's file type detection.

### DIFF
--- a/ftdetect/bzl.vim
+++ b/ftdetect/bzl.vim
@@ -12,4 +12,4 @@
 " See the License for the specific language governing permissions and
 " limitations under the License.
 
-autocmd BufRead,BufNewFile *.bzl,BUILD,BUILD.bazel,WORKSPACE setfiletype bzl
+autocmd BufRead,BufNewFile *.bzl,BUILD,*.BUILD,BUILD.*,WORKSPACE setfiletype bzl


### PR DESCRIPTION
These file patterns are commonly used as BUILD files specified in workspace rules.