### PR TITLE
Avoid matching lowercase files when fname_case feature is missing

### DIFF
--- a/ftdetect/bzl.vim
+++ b/ftdetect/bzl.vim
@@ -12,4 +12,7 @@
 " See the License for the specific language governing permissions and
 " limitations under the License.
 
-autocmd BufRead,BufNewFile *.bzl,BUILD,*.BUILD,BUILD.*,WORKSPACE setfiletype bzl
+autocmd BufRead,BufNewFile *.bzl,WORKSPACE setfiletype bzl
+if has('fname_case')
+  autocmd BufRead,BufNewFile BUILD,*.BUILD,BUILD.* setfiletype bzl
+endif


### PR DESCRIPTION
Put the BUILD, *.BUILD, and BUILD.* patterns behind a has('fname_case')
check so that on case-insensitive systems it doesn't false positive on
lowercase names. "build" is kind of a generic pattern if it's not
case-sensitive. Other patterns in vim's runtime/filetype.vim perform
similar checks.
See https://groups.google.com/d/topic/vim_dev/m0_mv6E63mE/discussion for
context.

Users can configure an explicit autocmd in their vimrc if they want the
case-insensitive match regardless.